### PR TITLE
Fixed bug where some looked-up names disappeared from the lookup dict

### DIFF
--- a/python-parser.py
+++ b/python-parser.py
@@ -1,7 +1,5 @@
 import collections
 import csv
-import operator
-import functools
 
 class NameDenormalizer(object):
     def __init__(self, filename=None):
@@ -19,7 +17,7 @@ class NameDenormalizer(object):
         name = name.lower()
         if name not in self.lookup:
             raise KeyError(name)
-        names = functools.reduce(operator.or_, self.lookup[name])
+        names = set().union(*self.lookup[name])
         if name in names:
             names.remove(name)
         return names


### PR DESCRIPTION
When testing `python-parser.py`, I noticed that if I looked up some names, they would disappear from the results of other lookups. For example:
```python
>>> name_denormalizer = NameDenormalizer()
>>> name_denormalizer.get("Ryan")
{'ry'}
>>> name_denormalizer.get("Ry")
set()
>>> name_denormalizer.get("Ryan")
set()
```
It was because of this line:
```python
names = functools.reduce(operator.or_, self.lookup[name])
```
Its purpose is to get the union of the sets in the list `self.lookup[name]`, but in the case that `self.lookup[name]` only contains one set, it sets `names` to the exact same set, by reference. So, the next two lines remove the name from the original set in the lookup dict:
```python
if name in names:
    names.remove(name)
```
I replaced the problematic line, and removed `operator` and `functools` as they are no longer used.